### PR TITLE
adafruit_si4713: prefer 'struct', falling back to 'ustruct'

### DIFF
--- a/adafruit_si4713.py
+++ b/adafruit_si4713.py
@@ -32,7 +32,10 @@ at: https://github.com/adafruit/Adafruit-Si4713-Library/
 import time
 
 from micropython import const
-import ustruct
+try:
+    import struct
+except ImportError:
+    import ustruct as struct
 
 import adafruit_bus_device.i2c_device as i2c_device
 
@@ -379,7 +382,7 @@ class SI4713:
         """
         # Perform ASQ request, then parse out 8 bit _signed_ input level value.
         self._asq_status()
-        return ustruct.unpack('bbbbb', self._BUFFER)[4]
+        return struct.unpack('bbbbb', self._BUFFER)[4]
 
     @property
     def audio_signal_status(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["micropython", "ustruct", "adafruit_bus_device", "adafruit_bus_device.i2c_device"]
+autodoc_mock_imports = ["micropython", "adafruit_bus_device", "adafruit_bus_device.i2c_device"]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'BusDevice': ('https://circuitpython.readthedocs.io/projects/bus_device/en/latest/', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}
 


### PR DESCRIPTION
As mentioned at adafruit/circuitpython#782 it will be necessary in CircuitPython 3.0 to import 'struct' instead of 'ustruct'.  Use the import syntax suggested in that issue, tidying up references to ustruct; a sphinx documentation workaround becomes unneeded by doing this.

I do not actually have the si4713 hardware, so I was unable to perform any testing.