### PR TITLE
fixes for cpython & pi: hard reset before i2c init, tighten struct.unpack()

### DIFF
--- a/adafruit_si4713.py
+++ b/adafruit_si4713.py
@@ -127,7 +127,7 @@ class SI4713:
         if self._reset is not None:
             self._reset.switch_to_output(value=True)
 
-            # Toggle reset line low to reset the chip and then wait a bit for 
+            # Toggle reset line low to reset the chip and then wait a bit for
             # startup - this is necessary before initializing as an i2c device
             # on at least the Raspberry Pi, and potentially elsewhere:
             self._reset.value = True

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,6 +3,6 @@ Simple test
 
 Ensure your device works with this simple test.
 
-.. literalinclude:: ../examples/simpletest.py
-    :caption: examples/simpletest.py
+.. literalinclude:: ../examples/si4713_simpletest.py
+    :caption: examples/si4713_simpletest.py
     :linenos:

--- a/examples/si4713_simpletest.py
+++ b/examples/si4713_simpletest.py
@@ -8,7 +8,6 @@ import digitalio
 
 import adafruit_si4713
 
-
 # Specify the FM frequency to transmit on in kilohertz.  As the datasheet
 # mentions you can only specify 50khz steps!
 FREQUENCY_KHZ = 102300  # 102.300mhz

--- a/examples/si4713_simpletest.py
+++ b/examples/si4713_simpletest.py
@@ -24,10 +24,10 @@ i2c = busio.I2C(board.SCL, board.SDA)
 # If you hooked up the reset line you should specify that too.  Make sure
 # to pass in a DigitalInOut instance.  You will need the reset pin with the
 # Raspberry Pi, and probably other devices:
-reset = digitalio.DigitalInOut(board.D5)
+si_reset = digitalio.DigitalInOut(board.D5)
 
 print('initializing si4713 instance')
-si4713 = adafruit_si4713.SI4713(i2c, reset=reset, timeout_s=0.5)
+si4713 = adafruit_si4713.SI4713(i2c, reset=si_reset, timeout_s=0.5)
 print('done')
 
 # Measure the noise level for the transmit frequency (this assumes automatic

--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -4,6 +4,7 @@ import time
 
 import board
 import busio
+import digitalio
 
 import adafruit_si4713
 
@@ -24,7 +25,6 @@ i2c = busio.I2C(board.SCL, board.SDA)
 # If you hooked up the reset line you should specify that too.  Make sure
 # to pass in a DigitalInOut instance.  You will need the reset pin with the
 # Raspberry Pi, and probably other devices:
-import digitalio
 reset = digitalio.DigitalInOut(board.D5)
 
 print('initializing si4713 instance')

--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -12,19 +12,24 @@ import adafruit_si4713
 # mentions you can only specify 50khz steps!
 FREQUENCY_KHZ = 102300  # 102.300mhz
 
-
 # Initialize I2C bus.
 i2c = busio.I2C(board.SCL, board.SDA)
 
 # Initialize SI4713.
-si4713 = adafruit_si4713.SI4713(i2c)
+# si4713 = adafruit_si4713.SI4713(i2c)
+
 # Alternatively you can specify the I2C address of the device if it changed:
-#si4713 = adafruit_si4713.SI4713(i2c, address=0x11)
-# Also if you hooked up the reset line you can specify that too.  Make sure
-# to pass in a DigitalInOut instance:
-#import digitalio
-#reset = digitalio.DigitalInOut(board.D5)
-#si4713 = adafruit_si4713.SI4713(i2c, reset=reset)
+# si4713 = adafruit_si4713.SI4713(i2c, address=0x11)
+
+# If you hooked up the reset line you should specify that too.  Make sure
+# to pass in a DigitalInOut instance.  You will need the reset pin with the
+# Raspberry Pi, and probably other devices:
+import digitalio
+reset = digitalio.DigitalInOut(board.D5)
+
+print('initializing si4713 instance')
+si4713 = adafruit_si4713.SI4713(i2c, reset=reset, timeout_s=0.5)
+print('done')
 
 # Measure the noise level for the transmit frequency (this assumes automatic
 # antenna capacitance setting, but see below to adjust to a specific value).


### PR DESCRIPTION
It's necessary to hook up the reset pin and toggle it before initializing the i2c device, at least with some hardware (including the Raspberry Pi).

struct.unpack() is stricter about inputs on CPython than under CircuitPython.

@kattni: Note this changes the example code a bit, we probably need to mention in guides that the reset pin isn't optional.