### PR TITLE
Updated adafruit_si4713.py to also recognize the si4721 chip.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Introduction
     :target: https://github.com/adafruit/Adafruit_CircuitPython_SI4713/actions/
     :alt: Build Status
 
-CircuitPython module for SI4713 FM RDS transmitter.
+CircuitPython module for SI4713 and SI4721 FM RDS transmitter.
 
 Dependencies
 =============

--- a/adafruit_si4713.py
+++ b/adafruit_si4713.py
@@ -122,8 +122,8 @@ class SI4713:
         self._device = i2c_device.I2CDevice(i2c, address)
         self.reset()
         # Check product ID.
-        if self._get_product_number() != 13:
-            raise RuntimeError("Failed to find SI4713, check wiring!")
+        if self._get_product_number() != 13 and self._get_product_number() != 21:
+            raise RuntimeError("Failed to find SI4713 or SI4721, check wiring!")
 
     def _read_u8(self, address):
         # Read an 8-bit unsigned value from the specified 8-bit address.


### PR DESCRIPTION
The SI4721 has an additional digital audio input but also an analog input.

It is backward compatible and will work in analog input mode as the si4713 chip.
I have not yet tested the digital input, this will be done later.

The only difference in the code: The SI4721 will return the product number 21 in stead of 13, the init function has been modified to accept either 13 or 21.
