### PR TITLE
solving_station_info

### DIFF
--- a/adafruit_si4713.py
+++ b/adafruit_si4713.py
@@ -454,7 +454,7 @@ class SI4713:
         station_length = len(station)
         assert 0 <= station_length <= 96
         # Fire off each 4 byte update of the station value.
-        for i in range(0, station_length, 4):
+        for i in range(0, 8, 4):
             self._BUFFER[0] = _SI4710_CMD_TX_RDS_PS
             self._BUFFER[1] = i // 4
             self._BUFFER[2] = station[i] if i < station_length else 0x00


### PR DESCRIPTION
This resolves #9 .

According to the data sheet page 28, this has to be setup only at powerup, however for testing purposes I change the station every three seconds, behavior in the video is normal as mentioned in the datasheet, the databuffer has a length of 4 characters, so it will update half buffer at a time

### Results
![20210604_195139_1](https://user-images.githubusercontent.com/34255413/120873626-e1c93100-c570-11eb-9f5b-93c64d8d79b3.gif)


### Hardware
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
```
with a Adafruit SI4713

### TEST CODE
```python
import board
import digitalio
import adafruit_si4713
import time
from random import choice

si_reset = digitalio.DigitalInOut(board.D5)
si4713 = adafruit_si4713.SI4713(board.I2C(), reset=si_reset, timeout_s=0.5)
si4713.tx_frequency_khz = 87600
si4713.tx_power = 115

stations = [b'-', b'IO', b'Neo', b'Hans', b"Cappy", b'Neokey', b'Minerva', b'Blinka', b'Adafruit']

while True:
    si4713.configure_rds(0xADAF, station=choice(stations), rds_buffer=b'Electronic Hits')
    time.sleep(2)
```